### PR TITLE
Remove Checking File Exntesion Of LocalAsset

### DIFF
--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -618,9 +618,7 @@ BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL)
   if (!name) {
     return NO;
   }
-
-  NSString *extension = [name pathExtension];
-  return [extension isEqualToString:@"png"] || [extension isEqualToString:@"jpg"];
+  return YES;
 }
 
 RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *extension, NSError **error)


### PR DESCRIPTION
Before this commit, native package's image couldn't load.
This commit remove file extension checking on `RCTIsLocalAssetURL`

Instead creating new PR on facebook/react-native, I wish if you agree with this commit, just merge it to your branch to edit your PR facebook/react-native#9130.
